### PR TITLE
Fix sickle

### DIFF
--- a/dryplants/init.lua
+++ b/dryplants/init.lua
@@ -31,6 +31,27 @@ end
 -----------------------------------------------------------------------------------------------
 -- Sickle
 -----------------------------------------------------------------------------------------------
+local function sickle_can_break(pos, deff, player)
+	local def = ItemStack({name=deff.name}):get_definition()
+
+	if not def.diggable or (def.can_dig and not def.can_dig(pos,player)) then
+		minetest.log("info", player:get_player_name() .. " tried to sickle "
+		.. def.name .. " which is not diggable "
+		.. minetest.pos_to_string(pos))
+		return
+	end
+
+	if minetest.is_protected(pos, player:get_player_name()) then
+		minetest.log("action", player:get_player_name()
+			.. " tried to sickle " .. def.name
+			.. " at protected position "
+			.. minetest.pos_to_string(pos))
+		minetest.record_protection_violation(pos, player:get_player_name())
+		return
+	end
+
+	return true
+end
 -- turns nodes with group flora=1 & flower=0 into cut grass
 local function sickle_on_use(itemstack, user, pointed_thing, uses)
 	local pt = pointed_thing
@@ -41,11 +62,11 @@ local function sickle_on_use(itemstack, user, pointed_thing, uses)
 	if pt.type ~= "node" then
 		return
 	end
-	
+
 	local under = minetest.get_node(pt.under)
-	local p = {x=pt.under.x, y=pt.under.y+1, z=pt.under.z}
-	local above = minetest.get_node(p)
-	
+	local above_pos = {x=pt.under.x, y=pt.under.y+1, z=pt.under.z}
+	local above = minetest.get_node(above_pos)
+
 	-- return if any of the nodes is not registered
 	if not minetest.registered_nodes[under.name] then
 		return
@@ -53,30 +74,15 @@ local function sickle_on_use(itemstack, user, pointed_thing, uses)
 	if not minetest.registered_nodes[above.name] then
 		return
 	end
-	
-	local node = minetest.get_node(pt.under)
+
 	-- check if something that can be cut using fine tools
 	if minetest.get_item_group(under.name, "snappy") > 0 then
 		-- check if flora but no flower
 		if minetest.get_item_group(under.name, "flora") == 1 and minetest.get_item_group(under.name, "flower") == 0 then
 			-- turn the node into cut grass, wear out item and play sound
 			minetest.set_node(pt.under, {name="dryplants:grass"})
-		else -- otherwise get the drop
-			local inv = user:get_inventory()
-			local name = minetest. get_node(pt.under).name
-			
-			local the_drop = minetest.registered_nodes[name].drop
-			
-			if the_drop ~= nil then
-				if inv:room_for_item("main", the_drop) then
-					inv:add_item("main", the_drop)
-				end
-			else
-				if inv:room_for_item("main", name) then
-					inv:add_item("main", name)
-				end
-			end
-			minetest.remove_node(pt.under)
+		else -- otherwise dig the node
+			minetest.dig_node(pt.under)
 		end
 		minetest.sound_play("default_dig_crumbly", {
 			pos = pt.under,
@@ -84,9 +90,15 @@ local function sickle_on_use(itemstack, user, pointed_thing, uses)
 		})
 		itemstack:add_wear(65535/(uses-1))
 		return itemstack
-	elseif string.find(node.name, "default:dirt_with_grass") then
+	elseif string.find(under.name, "default:dirt_with_grass") then
+		if not sickle_can_break(pt.under, under, user) then
+			return
+		end
+		if minetest.is_protected(above_pos, user:get_player_name()) or above.name ~= "air" then
+			return
+		end
 		minetest.set_node(pt.under, {name="dryplants:grass_short"})
-		minetest.set_node(pt.above, {name="dryplants:grass"})
+		minetest.set_node(above_pos, {name="dryplants:grass"})
 		minetest.sound_play("default_dig_crumbly", {
 			pos = pt.under,
 			gain = 0.5,


### PR DESCRIPTION
Fixes a bunch of issues with the sickle:
-sickle didnt care of protection
-sickle removed filled chests (also locked ones)
-when applying to a dirt node thats not "under" a player, the grass got added to the wrong position
-everything that was above a dirt_with_grass node got removed

Now I am proud to announce, that all these issues got resolved.