### PR TITLE
Fixes and improvements to blossom code

### DIFF
--- a/nature_classic/blossom.lua
+++ b/nature_classic/blossom.lua
@@ -30,35 +30,45 @@ minetest.register_craft({
 -- these ABMs can get heavy, so just enqueue the nodes
 
 -- Adding Blossoms
+-- Limit mass changes after block has not been loaded for some time:
+-- Run ABM with higher frequency, but don't enqueue all blocks
 minetest.register_abm({
     nodenames = { nature.blossom_leaves },
-    interval = nature.blossom_delay,
+    interval = nature.blossom_delay / nature.leaves_blossom_chance,
     chance = nature.leaves_blossom_chance,
 
     action = function(pos, node, active_object_count, active_object_count_wider)
-			nature.enqueue_node(pos, node, nature.blossom_node)
+			if math.random(nature.leaves_blossom_chance) == 1 then
+				nature.enqueue_node(pos, node, nature.blossom_node)
+			end
     end
 })
 
 -- Removing blossoms
+-- Limit mass changes after block has not been loaded for some time:
+-- Run ABM with higher frequency, but don't enqueue all blocks
 minetest.register_abm({
     nodenames = { nature.blossom_node },
-    interval = nature.blossom_delay,
+    interval = nature.blossom_delay / nature.blossom_leaves_chance,
     chance = nature.blossom_leaves_chance,
 
     action = function(pos, node, active_object_count, active_object_count_wider)
-			nature.enqueue_node(pos, node, nature.blossom_leaves)
+			if math.random(nature.blossom_leaves_chance) == 1 then
+				nature.enqueue_node(pos, node, nature.blossom_leaves)
+			end
     end
 })
 
 -- Spawning apples
+-- Limit mass changes after block has not been loaded for some time:
+-- spawn apples with 10% chance, but with 10 times higher frequency
 minetest.register_abm({
     nodenames = { nature.blossom_node },
-    interval = nature.blossom_delay,
+    interval = nature.blossom_delay / 10,
     chance = nature.apple_chance,
 
     action = function(pos, node, active_object_count, active_object_count_wider)
-		if nature.dtime < 0.2 and not minetest.find_node_near(pos, nature.apple_spread, { "default:apple" }) then
+		if math.random(10) == 0 and nature.dtime < 0.2 and not minetest.find_node_near(pos, nature.apple_spread, { "default:apple" }) then
 			spawn_apple_under(pos)
 		end
     end

--- a/nature_classic/blossom.lua
+++ b/nature_classic/blossom.lua
@@ -36,7 +36,7 @@ minetest.register_abm({
     chance = nature.blossom_chance,
 
     action = function(pos, node, active_object_count, active_object_count_wider)
-			nature.enqueue_node(pos, node, true)
+			nature.enqueue_node(pos, node, nature.blossom_node)
     end
 })
 
@@ -47,7 +47,7 @@ minetest.register_abm({
     chance = nature.blossom_chance,
 
     action = function(pos, node, active_object_count, active_object_count_wider)
-			nature.enqueue_node(pos, node, false)
+			nature.enqueue_node(pos, node, nature.blossom_leaves)
     end
 })
 

--- a/nature_classic/blossom.lua
+++ b/nature_classic/blossom.lua
@@ -33,7 +33,7 @@ minetest.register_craft({
 minetest.register_abm({
     nodenames = { nature.blossom_leaves },
     interval = nature.blossom_delay,
-    chance = nature.blossom_chance,
+    chance = nature.leaves_blossom_chance,
 
     action = function(pos, node, active_object_count, active_object_count_wider)
 			nature.enqueue_node(pos, node, nature.blossom_node)
@@ -44,7 +44,7 @@ minetest.register_abm({
 minetest.register_abm({
     nodenames = { nature.blossom_node },
     interval = nature.blossom_delay,
-    chance = nature.blossom_chance,
+    chance = nature.blossom_leaves_chance,
 
     action = function(pos, node, active_object_count, active_object_count_wider)
 			nature.enqueue_node(pos, node, nature.blossom_leaves)

--- a/nature_classic/global_function.lua
+++ b/nature_classic/global_function.lua
@@ -51,20 +51,14 @@ end
 local function set_young_node(pos)
     local meta = minetest.get_meta(pos)
 
-    meta:set_string(nature.node_young, nature.setting_true)
-    minetest.after(nature.youth_delay,
-        function(pos)
-            local meta = minetest.get_meta(pos)
-            meta:set_string(nature.node_young, nature.setting_false)
-        end,
-    pos)
+    meta:set_int(nature.meta_blossom_time, minetest.get_gametime())
 end
 
 local function is_not_young(pos)
     local meta = minetest.get_meta(pos)
 
-    local young = meta:get_string(nature.node_young)
-    return young ~= nature.setting_true
+    local blossom_time = meta:get_int(nature.meta_blossom_time)
+    return not (blossom_time and minetest.get_gametime() - blossom_time < nature.blossom_duration)
 end
 
 function nature:grow_node(pos, nodename)

--- a/nature_classic/global_function.lua
+++ b/nature_classic/global_function.lua
@@ -73,7 +73,6 @@ function nature:grow_node(pos, nodename)
                 >= nature.minimum_growth_light 
 
         if is_not_young(pos) and light_enough then
-            minetest.remove_node(pos)
             minetest.set_node(pos, { name = nodename })
             set_young_node(pos)
 

--- a/nature_classic/global_function.lua
+++ b/nature_classic/global_function.lua
@@ -5,21 +5,22 @@ minetest.register_globalstep(function(dtime)
 	if #nature.blossomqueue > 0 and dtime < 0.2 then
 		local pos  = nature.blossomqueue[1][1]
 		local node = nature.blossomqueue[1][2]
-		if (nature.blossomqueue[1][3] and not nature:is_near_water(pos)) then
+		local replace = nature.blossomqueue[1][3]
+		if (nature.blossomqueue[1][3] == nature.blossom_node and not nature:is_near_water(pos)) then
 			table.remove(nature.blossomqueue, 1) -- don't grow if it's not near water, pop from queue.
 			return
 		end
-		nature:grow_node(pos, nature.blossom_node) -- now actually grow it.
+		nature:grow_node(pos, replace) -- now actually grow it.
 		table.remove(nature.blossomqueue, 1)
 	end
 end)
 
-function nature.enqueue_node(pos, node, fcn)
+function nature.enqueue_node(pos, node, replace)
 	local idx = #nature.blossomqueue
 	nature.blossomqueue[idx+1] = {}
 	nature.blossomqueue[idx+1][1] = pos
 	nature.blossomqueue[idx+1][2] = node
-	nature.blossomqueue[idx+1][3] = fcn
+	nature.blossomqueue[idx+1][3] = replace
 end
 
 local function set_young_node(pos)

--- a/nature_classic/init.lua
+++ b/nature_classic/init.lua
@@ -19,7 +19,8 @@ if minetest.get_modpath("moretrees") then
 	minetest.register_alias("nature:blossom", "default:leaves")
 end
 
-nature.blossom_chance = 15
+nature.leaves_blossom_chance = 15
+nature.blossom_leaves_chance = 5
 nature.blossom_delay = 3600
 nature.apple_chance = 10
 nature.apple_spread = 2

--- a/nature_classic/init.lua
+++ b/nature_classic/init.lua
@@ -26,10 +26,8 @@ nature.blossom_delay = 3600
 nature.apple_chance = 10
 nature.apple_spread = 2
 
-nature.node_young = "young"
-nature.setting_true = "true"
-nature.setting_false = "false"
-nature.youth_delay = 5
+nature.meta_blossom_time = "blossom_time"
+nature.blossom_duration = 5
 
 function dumppos(pos)
 	return "("..pos.x..","..pos.y..","..pos.z..")"

--- a/nature_classic/init.lua
+++ b/nature_classic/init.lua
@@ -7,6 +7,7 @@ local current_mod_name = minetest.get_current_modname()
 
 nature = {}
 nature.blossomqueue = {}
+nature.blossomqueue_max = 1000
 
 nature.blossom_node = "nature:blossom"
 nature.blossom_leaves = "default:leaves"

--- a/nature_classic/init.lua
+++ b/nature_classic/init.lua
@@ -27,7 +27,7 @@ nature.apple_chance = 10
 nature.apple_spread = 2
 
 nature.meta_blossom_time = "blossom_time"
-nature.blossom_duration = 5
+nature.blossom_duration = nature.blossom_delay
 
 function dumppos(pos)
 	return "("..pos.x..","..pos.y..","..pos.z..")"


### PR DESCRIPTION
Hi,

I'd like to propose some changes for inclusion:
* Made blossom change back to leaves over time (it didn't, causing all-blossom trees)
* Limited the total number of blossoms queued for conversion
* Fixed a bug causing persistent blossoms (that would never change back to leaves)
* Reduced mass conversions between blossoms and leaves, which happened after a map-block was loaded again after a long time.

Rogier.